### PR TITLE
Add Turn Tracker, Trees

### DIFF
--- a/source/classes/Lists/SortedList.mts
+++ b/source/classes/Lists/SortedList.mts
@@ -1,0 +1,102 @@
+import type {
+	matchMethod,
+	sortMethod,
+} from '#types/aliases.d.mts'
+
+interface SortedListArgs <Item> {
+	sortMethod: sortMethod<Item>,
+	matchMethod?: matchMethod<Item>,
+	items?: Array<Item>,
+}
+
+/** A list that is guarenteed to remain in sorted order. */
+class SortedList <Item = unknown> {
+	#sortMethod: sortMethod<Item>
+	#matchMethod: matchMethod<Item>
+	#sortedList: Array<Item> = [ ]
+
+	/**
+	While creating a sorted list, you must specify a
+		sort method for the internal list to abide by.
+	You may also specify a match method, which can be
+		optionally used to check if two list items are equal.
+
+	---
+
+	@param args
+	<!-- Used for tracking the spread arguments. --->
+
+	---
+
+	@param args.sortMethod
+	The sort method which the list abides by.
+
+	---
+
+	@param args.matchMethod
+	_Optional._
+	How the list determines item equality.
+	Used to find matching items with `this.remove( )`.
+
+	---
+
+	@param args.items
+	_Optional._
+	If specified, these items will be added to the list.
+	**/
+	constructor ({
+		sortMethod,
+		matchMethod = (a, b) => (a === b),
+		items = [ ],
+	}: SortedListArgs<Item>) {
+		this.#sortMethod = sortMethod
+		this.#matchMethod = matchMethod
+		this.add(...items)
+	}
+
+	/** Provides a read-only copy of the sorted list. */
+	get list ( ) {return [...this.#sortedList] as const}
+
+	/** Sorts the list. Accessible on class instances. */
+	sort ( ) {this.#sortedList.sort(this.#sortMethod)}
+
+	/**
+	Adds one or more items to the list,
+		while maintaining sort order.
+	**/
+	add (...items: Array<Item>) {
+		this.#sortedList.push(...items)
+		this.sort( )
+
+		// Return all additions.
+		return [...items] as const
+	}
+
+	/**
+	Removes one or more items from the list.
+	If multiple matches exist for a single item,
+		then only the first match is removed from the list.
+	**/
+	remove (...items: Array<Item>) {
+		// Track and return all successfully removed items.
+		const removals: Array<Item> = [ ]
+
+		items.forEach((item) => {
+			// Find the first element that matches the item.
+			const index = this.#sortedList.findIndex((target) => (
+				this.#matchMethod(target, item)
+			))
+
+			// Remove the element at the matched index.
+			if (index >= 0) {
+				const removed = this.#sortedList.splice(index, 1)
+				if (removed.length > 0) removals.push(item)
+			}
+		})
+
+		return [...removals] as const
+	}
+}
+
+export {SortedList}
+export type {SortedListArgs}

--- a/source/classes/Lists/index.mts
+++ b/source/classes/Lists/index.mts
@@ -1,0 +1,2 @@
+export {SortedList} from './SortedList.mts'
+export type {SortedListArgs} from './SortedList.mts'

--- a/source/classes/Trees/AbstractTrees/AbstractBilateralTree.mts
+++ b/source/classes/Trees/AbstractTrees/AbstractBilateralTree.mts
@@ -1,0 +1,43 @@
+import {AbstractTree} from './index.mts'
+
+abstract class AbstractBilateralTree <Data = never>
+extends AbstractTree<Data> {
+	/* ******************** */
+	/* # MUTATION METHODS # */
+	/* ******************** */
+
+	abstract override add (target: this): boolean
+
+	/* ************************* */
+	/* # INTROSPECTION METHODS # */
+	/* ************************* */
+
+	abstract override isChild ( ): boolean
+	abstract override isRoot ( ): boolean
+
+	/* ******************** */
+	/* # RELATION METHODS # */
+	/* ******************** */
+
+	abstract override hasParent (target: this): boolean
+	abstract override hasAncestor (target: this): boolean
+	abstract override hasRoot (target: this): boolean
+
+	abstract override hasRelative (target: this): boolean
+
+	/* ********************** */
+	/* # COLLECTION METHODS # */
+	/* ********************** */
+
+	abstract override getParent ( ): this | null
+	abstract override getAncestors ( ): ReadonlyArray<this>
+	abstract override getRoot ( ): this
+
+	abstract override getRelatives ( ): ReadonlyArray<this>
+
+	/* ********************* */
+	/* # TRAVERSAL METHODS # */
+	/* ********************* */
+}
+
+export {AbstractBilateralTree}

--- a/source/classes/Trees/AbstractTrees/AbstractTree.mts
+++ b/source/classes/Trees/AbstractTrees/AbstractTree.mts
@@ -1,0 +1,194 @@
+import type {
+	GraphPath,
+	VisitFx,
+	TraversalOptions,
+} from '../index.mts'
+
+abstract class AbstractTree <Data = never> {
+	abstract data?: Data | undefined
+	constructor (data?: Data) { }
+
+	/* ********************* */
+	/* # GETTER PROPERTIES # */
+	/* ********************* */
+
+	/** Counts this tree's children. */
+	abstract get size ( ): number
+
+	/**
+	Provides this tree's children in an array.
+	This property is an alias for `this.getChildren( )`.
+	**/
+	abstract get children ( ): ReadonlyArray<this>
+
+	/* ******************** */
+	/* # MUTATION METHODS # */
+	/* ******************** */
+
+	/**
+	Attempts to add a specified target node to this tree.
+	The target must not be be related to this tree, and cannot
+		be a child of another node (ie, it must be a root node).
+	If the target node cannot be added to this tree,
+		then the value `false` is returned by this method.
+
+	---
+
+	@param target
+	The target node to be added to this tree.
+
+	---
+
+	@param root
+	The root node of this tree.
+
+	---
+
+	@param targetRoot
+	The root node of the specified target.
+
+	---
+
+	@returns
+	The returned value represents whether or not the target
+		was successfully added to this tree.
+	**/
+	abstract add (
+		target: this,
+		root: this,
+		targetRoot: this,
+	): boolean
+
+	/**
+	If the target node is a child of this tree, it is deleted.
+	If it is deleted successfully, then its children are also
+		adopted by this tree (which differs from `this.prune`).
+	**/
+	abstract delete (target: this): boolean
+
+	/**
+	If the target node is a child of this tree, it is deleted.
+	Even if it is deleted successfully, it gets to keep its
+		children (which differs from `this.delete`).
+	**/
+	abstract prune (target: this): boolean
+
+	/**
+	Creates a new instance of a tree as a child node.
+	The new child node is returned by this method; however,
+		if this tree cannot add the child, `null` is returned.
+	**/
+	abstract create ( ): this | null
+
+	/* ************************* */
+	/* # INTROSPECTION METHODS # */
+	/* ************************* */
+
+	/** Determines if this tree is a parent node. */
+	abstract isParent ( ): boolean
+	/** Determines if this tree is a leaf node. */
+	abstract isLeaf ( ): boolean
+
+	// LOOK-BEHIND FEATURES //
+
+	/** Determines if this tree is a child node. */
+	abstract isChild (root: this): boolean
+	/** Determines if this tree is a root node. */
+	abstract isRoot (root: this): boolean
+
+	/* ******************** */
+	/* # RELATION METHODS # */
+	/* ******************** */
+
+	/**
+	Determines if this tree has a given child node.
+	The method is an alias for `this.hasChild( )`.
+	**/
+	abstract has (target: this): boolean
+
+	/** Determines if this tree has a given child node. */
+	abstract hasChild (target: this): boolean
+	/** Determines if this tree has a given descendant. */
+	abstract hasDescendant (target: this): boolean
+	/** Determines if this tree has a given leaf node. */
+	abstract hasLeaf (target: this): boolean
+
+	// LOOK-BEHIND FEATURES //
+
+	/** Determines if this tree has a given parent node. */
+	abstract hasParent (target: this, root: this): boolean
+	/** Determines if this tree has a given ancestor. */
+	abstract hasAncestor (target: this, root: this): boolean
+	/** Determines if this tree has a given root node. */
+	abstract hasRoot (target: this, root: this): boolean
+
+	/** Determines if this tree has a given relative. */
+	abstract hasRelative (target: this, root: this): boolean
+
+	/* ********************** */
+	/* # COLLECTION METHODS # */
+	/* ********************** */
+
+	/** Collects this tree's children in an array. */
+	abstract getChildren ( ): ReadonlyArray<this>
+	/** Collects this tree's descendants in an array. */
+	abstract getDescendants ( ): ReadonlyArray<this>
+	/** Collects this tree's leaves in an array. */
+	abstract getLeaves ( ): ReadonlyArray<this>
+
+	// LOOK-BEHIND FEATURES //
+
+	/** Collects this tree's parent, if it has one. */
+	abstract getParent (root: this): this | null
+	/** Collects this tree's ancestors in an array. */
+	abstract getAncestors (root: this): ReadonlyArray<this>
+	/** Collects this tree's root, which can be itself. */
+	abstract getRoot (root: this): this
+
+	/** Collects all of this tree's relatives in an array. */
+	abstract getRelatives (root: this): ReadonlyArray<this>
+
+	/* ********************* */
+	/* # TRAVERSAL METHODS # */
+	/* ********************* */
+
+	/** Obtains a path to the given target descendant node. */
+	abstract findPathTo (target: this): GraphPath<this> | null
+
+	/**
+	Traverses the tree and runs a given function, `visitFx`.
+	Optionally, you may specify whether it traverses the tree
+		using a *"breadth-first"* or *"depth-first"* approach.
+
+	---
+
+	@param visitFx
+	A function that runs on each step of traversal, which can
+		take in the current node and its metadata as parameters.
+	It can return `true` to stop traversing the tree;
+		in this way, it can be used as a search method.
+
+	---
+
+	@param options
+	<!-- Used for optional additions. --->
+
+	---
+
+	@param options.approach
+	_Optional._
+	Can be set to either *"breadth-first"* or *"depth-first"*.
+
+	---
+
+	@returns
+	The returned boolean determines whether the given visit
+		function, `visitFx`, returned `true` with any node.
+	**/
+	abstract traverse (
+		visitFx: VisitFx<this>,
+		options: TraversalOptions,
+	): boolean
+}
+
+export {AbstractTree}

--- a/source/classes/Trees/AbstractTrees/index.mts
+++ b/source/classes/Trees/AbstractTrees/index.mts
@@ -1,1 +1,2 @@
 export {AbstractTree} from './AbstractTree.mts'
+export {AbstractBilateralTree} from './AbstractBilateralTree.mts'

--- a/source/classes/Trees/AbstractTrees/index.mts
+++ b/source/classes/Trees/AbstractTrees/index.mts
@@ -1,0 +1,1 @@
+export {AbstractTree} from './AbstractTree.mts'

--- a/source/classes/Trees/RootedTree.mts
+++ b/source/classes/Trees/RootedTree.mts
@@ -1,0 +1,107 @@
+import {AbstractBilateralTree} from './AbstractTrees/index.mts'
+import {AdoptionOptions, Tree} from './index.mts'
+
+class RootedTree <Data = never> extends Tree<Data>
+implements AbstractBilateralTree<Data> {
+	protected _root: this = this
+
+	/* ********************* */
+	/* # GETTER PROPERTIES # */
+	/* ********************* */
+
+	/**
+	Collects this tree's root, which can be itself.
+	This property is an alias for `this.getRoot( )`.
+	**/
+	get root ( ): this {
+		return this.getRoot( )
+	}
+
+	/* ******************** */
+	/* # MUTATION METHODS # */
+	/* ******************** */
+
+	protected override _forceAdoption (target: this): boolean {
+		return super._forceAdoption(target, target._root)
+	}
+
+	override add (target: this): boolean {
+		const success = super.add(this._root, target, target._root)
+		if (success) {
+			target.traverse((tree) => {
+				tree._root = this._root
+			})
+		}
+		return success
+	}
+
+	override prune (target: this): boolean {
+		const success = this._children.has(target)
+		if (success) {
+			target.traverse((tree) => {
+				tree._root = target
+			})
+		}
+		return super.prune(target)
+	}
+
+	override create (data?: Data): this {
+		const child = super.create(data)
+		child._root = this._root
+		return child
+	}
+
+	/* ************************* */
+	/* # INTROSPECTION METHODS # */
+	/* ************************* */
+
+	override isChild ( ): boolean {
+		return super.isChild(this._root)
+	}
+
+	override isRoot ( ): boolean {
+		return super.isRoot(this._root)
+	}
+
+	/* ******************** */
+	/* # RELATION METHODS # */
+	/* ******************** */
+
+	override hasParent (target: this): boolean {
+		return super.hasParent(target, this._root)
+	}
+
+	override hasAncestor (target: this): boolean {
+		return super.hasAncestor(target, this._root)
+	}
+
+	override hasRoot (target: this): boolean {
+		return super.hasRoot(target, this._root)
+	}
+
+	override hasRelative (target: this): boolean {
+		return super.hasRelative(target, this._root)
+	}
+
+	/* ********************** */
+	/* # COLLECTION METHODS # */
+	/* ********************** */
+
+	override getParent ( ): this | null {
+		return super.getParent(this._root)
+	}
+
+	override getAncestors ( ): ReadonlyArray<this> {
+		return super.getAncestors(this._root)
+	}
+
+	override getRoot ( ): this {
+		return super.getRoot(this._root)
+	}
+
+	override getRelatives ( ): ReadonlyArray<this> {
+		return super.getRelatives(this._root)
+	}
+}
+
+export {RootedTree}

--- a/source/classes/Trees/Tree.mts
+++ b/source/classes/Trees/Tree.mts
@@ -1,0 +1,297 @@
+import {AbstractTree} from './index.mts'
+
+import type {Constructor} from '#types/aliases'
+import type {
+	GraphPath,
+	VisitData,
+	VisitFx,
+	TraversalOptions,
+	AdoptionOptions,
+} from './index.mts'
+
+const missingPath = new Error(
+	'There is no path to the descendant node!',
+)
+
+class Tree <Data = never> extends AbstractTree<Data> {
+	protected _children: Set<this> = new Set( )
+	data?: Data | undefined
+
+	constructor (data?: Data) {
+		super(data) // Dummy constructor; does nothing.
+		this.data = data
+	}
+
+	/* ********************* */
+	/* # GETTER PROPERTIES # */
+	/* ********************* */
+
+	get size ( ): number {
+		return this._children.size
+	}
+
+	get children ( ): ReadonlyArray<this> {
+		return [...this._children]
+	}
+
+	/* ******************** */
+	/* # MUTATION METHODS # */
+	/* ******************** */
+
+	#dangerouslyAdd (target: this): boolean {
+		if (this.has(target)) return false
+		this._children.add(target)
+		return true
+	}
+
+	protected _forceAdoption (
+		target: this,
+		targetRoot: this,
+	): boolean {
+		const targetParent = target.getParent(targetRoot)
+		targetParent?.prune(target)
+		return this.#dangerouslyAdd(target)
+	}
+
+	add (
+		target: this,
+		root: this,
+		targetRoot: this,
+	): boolean {
+		// Determine that the target has no parent,
+		//	and is not related to this tree.
+		if (
+			target.isChild(targetRoot) ||
+			this.hasRelative(target, root)
+		) {return false}
+
+		this._children.add(target)
+		return true
+	}
+
+	delete (target: this): boolean {
+		const success = this.prune(target)
+		if (success) { // Adopt the target's children.
+			target.children.forEach((child) => {
+				this._forceAdoption(child, target)
+			})
+		}
+		return success
+	}
+
+
+	prune (target: this): boolean {
+		// The target keeps its children here.
+		return this._children.delete(target)
+	}
+
+	create (data?: Data): this {
+		// * NOTE * * * * * * * * * * * * * * * * * * * * * * *
+		// * Sadly, we must cast `this.constructor`, as it has
+		// *	an ambiguous type `Function`; not a constructor...
+		// * Neither can we obtain strongly-typed arguments by
+		// *	the likes of `ConstructorParameters<typeof this>`.
+		const Class = this.constructor as (
+			// We'll make do by using this custom type.
+			Constructor<this, [data?: Data]>
+		)
+		const child = new Class(data)
+		this.#dangerouslyAdd(child)
+		return child
+	}
+
+	/* ************************* */
+	/* # INTROSPECTION METHODS # */
+	/* ************************* */
+
+	isParent ( ): boolean {
+		return this.size > 0
+	}
+
+	isLeaf ( ): boolean {
+		return this.size === 0
+	}
+
+	// LOOK-BEHIND FEATURES //
+
+	isChild (root: this): boolean {
+		return this.getParent(root) !== null
+	}
+
+	isRoot (root: this): boolean {
+		return this.getRoot(root) === this
+	}
+
+	/* ******************** */
+	/* # RELATION METHODS # */
+	/* ******************** */
+
+	has (target: this): boolean {
+		return this._children.has(target)
+	}
+
+	hasChild (target: this): boolean {
+		return this.has(target)
+	}
+
+	hasDescendant (target: this): boolean {
+		// A tree can't be its own descendant.
+		if (this === target) return false
+		const predicate = (tree: this) => {
+			return tree === target
+		}
+		return this.traverse(predicate)
+	}
+
+	hasLeaf (target: this): boolean {
+		// Check if the target is a leaf.
+		if (!target.isLeaf( )) return false
+		// Then, check if the target is in this tree.
+		if (this === target) return true
+		return this.hasDescendant(target)
+	}
+
+	// LOOK-BEHIND FEATURES //
+
+	hasParent (target: this, root: this): boolean {
+		return this.getParent(root) === target
+	}
+
+	hasAncestor (target: this, root: this): boolean {
+		return this.getAncestors(root).includes(target)
+	}
+
+	hasRoot (target: this, root: this): boolean {
+		return this.getRoot(root) === target
+	}
+
+	hasRelative (target: this, root: this): boolean {
+		// Both `this` and `target` must either be descendants
+		//	of the root, or be the actual root itself.
+		let foundThis = false
+		let foundTarget = false
+		const predicate = (tree: this) => {
+			if (tree === this) foundThis = true
+			if (tree === target) foundTarget = true
+			if (foundThis && foundTarget) return true
+			return false
+		}
+
+		return root.traverse(predicate)
+	}
+
+	/* ********************** */
+	/* # COLLECTION METHODS # */
+	/* ********************** */
+
+	getChildren ( ): ReadonlyArray<this> {
+		return this.children
+	}
+
+	getDescendants ( ): ReadonlyArray<this> {
+		const descendants: Array<this> = [ ]
+		const mutator = (tree: this) => {
+			// A tree cannot be its own descendant.
+			if (this !== tree) descendants.push(tree)
+		}
+		this.traverse(mutator)
+		return descendants
+	}
+
+	getLeaves ( ): ReadonlyArray<this> {
+		const leaves: Array<this> = [ ]
+		const mutator = (tree: this) => {
+			if (tree.isLeaf( )) leaves.push(tree)
+		}
+		this.traverse(mutator)
+		return leaves
+	}
+
+	// LOOK-BEHIND FEATURES //
+
+	getParent (root: this): this | null {
+		const ancestors = this.getAncestors(root)
+		return ancestors.at(-1) ?? null
+	}
+
+	getAncestors (root: this): ReadonlyArray<this> {
+		const path = root.findPathTo(this)
+		if (path == null) throw missingPath
+		return path.slice(0, -1)
+	}
+
+	getRoot (root: this): this {
+		const path = root.findPathTo(this)
+		if (path == null) throw missingPath
+		return path.at(0)!
+	}
+
+	getRelatives (root: this): ReadonlyArray<this> {
+		const relatives = [root, ...root.getDescendants( )]
+		return relatives
+	}
+
+	/* ********************* */
+	/* # TRAVERSAL METHODS # */
+	/* ********************* */
+
+	findPathTo (target: this): GraphPath<this> | null {
+		let path: GraphPath<this> | null = null
+		const mutator = (tree: this, data: VisitData<this>) => {
+			if (tree === target) {
+				path = data.path
+				return true // Exit early
+			}
+			return false
+		}
+		this.traverse(mutator)
+		return path
+	}
+
+	traverse (
+		visitFx: VisitFx<this>,
+		options: TraversalOptions = {approach: 'breadth-first'},
+	): boolean {
+		// This paths array starts with just this tree itself;
+		//	all other paths branch off from this tree.
+		const pendingPaths: Array<GraphPath<this>> = [[this]]
+
+		// The pending paths array can act like either a stack
+		//	or a queue, depending on this remove method.
+		const next = ( ) => {
+			switch (options.approach) {
+				case ('breadth-first'): {return pendingPaths.pop( )}
+				case ('depth-first'): {return pendingPaths.shift( )}
+			}
+		}
+
+		// Take the current path from the pending array.
+		let currentPath: GraphPath<this> | undefined
+		while ((currentPath = next( )) != null) {
+			// Get the current node and its metadata.
+			const current = currentPath.at(-1)!
+			const metadata = {
+				path: currentPath,
+				depth: currentPath.length - 1,
+			}
+
+			// Visit the current node with optional metadata.
+			const breakout = visitFx(current, metadata)
+			// Note, `visitFx` can be a predicate to exit early.
+			if (breakout === true) return true
+
+			// Add child paths to the pending array.
+			current.children.forEach((child) => {
+				const childPath: GraphPath<this> = [
+					...currentPath!,
+					child,
+				]
+				pendingPaths.push(childPath)
+			})
+		}
+
+		return false // Loop completed.
+	}
+}
+
+export {Tree}

--- a/source/classes/Trees/index.mts
+++ b/source/classes/Trees/index.mts
@@ -3,6 +3,8 @@ export {
 	AbstractBilateralTree,
 } from './AbstractTrees/index.mts'
 
+export {Tree} from './Tree.mts'
+
 export type {
 	GraphPath,
 	VisitData,

--- a/source/classes/Trees/index.mts
+++ b/source/classes/Trees/index.mts
@@ -1,3 +1,5 @@
+export {AbstractTree} from './AbstractTrees/index.mts'
+
 export type {
 	GraphPath,
 	VisitData,

--- a/source/classes/Trees/index.mts
+++ b/source/classes/Trees/index.mts
@@ -1,4 +1,7 @@
-export {AbstractTree} from './AbstractTrees/index.mts'
+export {
+	AbstractTree,
+	AbstractBilateralTree,
+} from './AbstractTrees/index.mts'
 
 export type {
 	GraphPath,

--- a/source/classes/Trees/index.mts
+++ b/source/classes/Trees/index.mts
@@ -4,6 +4,7 @@ export {
 } from './AbstractTrees/index.mts'
 
 export {Tree} from './Tree.mts'
+export {RootedTree} from './RootedTree.mts'
 
 export type {
 	GraphPath,

--- a/source/classes/Trees/index.mts
+++ b/source/classes/Trees/index.mts
@@ -1,0 +1,8 @@
+export type {
+	GraphPath,
+	VisitData,
+	VisitFx,
+	TraversalApproach,
+	TraversalOptions,
+	AdoptionOptions,
+} from './tree-types.d.mts'

--- a/source/classes/Trees/tree-types.d.mts
+++ b/source/classes/Trees/tree-types.d.mts
@@ -1,0 +1,33 @@
+type GraphPath <Node = unknown> = Readonly<[
+	root: Node,
+	...rest: Array<Node>
+]>
+
+type VisitData <Node = unknown> = Readonly<{
+	depth: number,
+	path: GraphPath<Node>,
+}>
+
+type VisitFx <Node = unknown> = (
+	node: Node,
+	data: VisitData<Node>,
+) => boolean | void
+
+type TraversalApproach = 'breadth-first' | 'depth-first'
+
+type TraversalOptions = Readonly<{
+	approach: TraversalApproach,
+}>
+
+type AdoptionOptions = Readonly<{
+	forceAdoption: boolean,
+}>
+
+export type {
+	GraphPath,
+	VisitData,
+	VisitFx,
+	TraversalApproach,
+	TraversalOptions,
+	AdoptionOptions,
+}

--- a/source/classes/TurnTracker/TurnTracker.mts
+++ b/source/classes/TurnTracker/TurnTracker.mts
@@ -1,0 +1,425 @@
+import JSON5 from 'json5'
+
+import {SortedList} from '#classes/Lists'
+import {makeTable} from '#tools/tables'
+
+import type {SortedListArgs} from '#classes/Lists'
+import type {integer, checkMethod} from '#types/aliases'
+
+/** A Turn containing index metadata. Can be nullish. */
+type MetaTurn<Type> = {index: integer, turn: Type} | null
+
+/** Describes a turn's index relative to the current turn. */
+type TurnRelation = (
+	| 'first-turn'
+	| 'next-turn'
+	// | 'previous-turn' // UNSUPPORTED
+	// | 'last-turn' // UNSUPPORTED
+)
+
+interface TurnTrackerArgs<Turn>
+extends SortedListArgs<Turn> {
+	filterMethod?: checkMethod<Turn>,
+}
+
+const invalidTurnError = new Error(
+	'Either the turn index is out of range, ' +
+	'or the turn is undefined!'
+)
+
+/**
+The __TurnTracker__ class is an abstraction of a
+	round-robin-style turn tracker.
+**/
+class TurnTracker<Turn = unknown> {
+	#listRef: SortedList<Turn>
+	#filterMethod: checkMethod<Turn>
+	#current: MetaTurn<Turn> = null
+	#turnCounter: integer = 0
+	#roundCounter: integer = 0
+
+	/**
+	Creates an instance of a __TurnTracker__, to be used for
+		tracking a round-robin-style turn-based activity.
+
+	---
+
+	@param args
+	<!-- Used for tracking the spread arguments. --->
+
+	---
+
+	@param args.sortMethod
+	Determines how a pair of turns are given priority.
+	Usually, you will want the turn with the higher _"rank"_
+		to go first, whatever that means for your application.
+
+	---
+
+	@param args.matchMethod
+	_Optional._
+	Determines whether a pair of turns are equal or not.
+	By default, this just uses JavaScript's "`===`" operator.
+
+	---
+
+	@param args.filterMethod
+	_Optional._
+	Determines which turns to filter out, when cycling
+		through the internal list of turns.
+	By default, this returns `true`, and keeps all turns.
+
+	---
+
+	@param args.items
+	_Optional._
+	When creating an instance, you may optionally
+		specify some turns to add to the tracker's queue.
+	**/
+	constructor ({
+		filterMethod = ( ) => true,
+		items = [ ],
+		...args
+	}: TurnTrackerArgs<Turn>) {
+		this.#listRef = new SortedList(args)
+		this.#filterMethod = filterMethod
+		this.add(...items)
+	}
+
+	/* *********************** */
+	/* # MAINTENANCE METHODS # */
+	/* *********************** */
+
+	/**
+	Automatically handles turn transitions.
+
+	The logic may appear somewhat intimidating to understand,
+		so try to understand each conditional block on its own.
+	Then, it may become more apparent, as they contain simple
+		sequential scripts that describe the tracker's state.
+
+	---
+
+	@param original
+	The current turn with index metadata.
+	A `null` value means there is no turn selected.
+
+	---
+
+	@param upcoming
+	The next turn with index metadata.
+	A `null` value indicates an intent
+		to deactivate the tracker.
+
+	---
+
+	@param options
+	_Optional._
+	Additional options to specify the method's behavior.
+
+	---
+
+	@param options.skip
+	_Optional._
+	If a turn is skipped, the counter doesn't increment.
+	**/
+	#safelyCycleTurn (
+		original: MetaTurn<Turn>,
+		upcoming: MetaTurn<Turn>,
+		{skip = false} = { }, // Options
+	) {
+		// The tracker is inactive and remains inactive.
+		if (original == null && upcoming == null) {
+			return
+		}
+		// Activate the tracker (it is deactivated).
+		else if (original == null) {
+			// TypeScript thinks `upcoming` can be nullish.
+			upcoming = upcoming! // It can't - tell TypeScript!
+			this.#current = upcoming
+		}
+		// Deactivate the tracker (it is activated).
+		else if (upcoming == null) {
+			this.#current = upcoming
+			this.#roundCounter++
+		}
+		// The upcoming turn is ahead of the original turn.
+		else if (upcoming.index > original.index) {
+			this.#current = upcoming
+			skip || this.#turnCounter++
+		}
+		// The upcoming turn is behind the orginal turn.
+		else {
+			this.#current = upcoming
+			this.#roundCounter++
+			skip || this.#turnCounter++
+		}
+	}
+
+	/**
+	Runs a callback safely, keeping the data structure intact.
+
+	---
+
+	@param callback
+	The callback is expected to mutate the list.
+	It can take one of two forms:
+	- It can add many turns to the list and move turns around.
+	- Or, it can remove one (and only one) turn from the list.
+
+	__Notice:__
+	The callback's logic should not be mixed and matched.
+	It should take only one of the aforementioned forms,
+		otherwise the current turn index can be scrambled!
+	**/
+	#safelyRunWithSideEffects (callback: ( ) => void) {
+		// Gather the "original" and "upcoming" turn list states
+		//	to determine whether turns were added or removed.
+		const originalTurns = this.turns
+		callback( ) // Execute the callback.
+		const upcomingTurns = this.turns
+
+		// Gather the "original" and "upcoming" turn states
+		//	to determine whether the current turn shifted.
+		const original = this.#current
+		if (original == null) return // Tracker was disabled.
+		const upcoming = this.getEntryAt(original.index)
+
+		// This determines if the original turn is still valid.
+		const originalIsValid = this.#filterMethod(original.turn)
+
+		// This determines the new index of the original turn.
+		let shiftedIndex; {
+			shiftedIndex = upcomingTurns.indexOf(original.turn)
+			if (shiftedIndex === -1) shiftedIndex = undefined
+		}
+
+		// The original turn hasn't shifted at all.
+		if (originalIsValid && original.turn === upcoming?.turn) {
+			return // No need to touch any variables.
+		}
+
+		// The original turn has shifted to a new index.
+		else if (originalIsValid && shiftedIndex != null) {
+			this.#current = {
+				index: shiftedIndex,
+				turn: original.turn,
+			} as const
+		}
+
+		// The original turn was deleted. Skip the turn!
+		else {
+			this.#safelyCycleTurn(
+				original,
+				upcoming,
+				{skip: true},
+			)
+		}
+	}
+
+	/* ******************************* */
+	/* # GETTER PROPERTIES & METHODS # */
+	/* ******************************* */
+
+	/** Provides a readonly copy of the turn tracker. */
+	get turns ( ) {return this.#listRef.list}
+
+	/** Determines if the tracker is set to active. */
+	get active ( ) {return this.#current != null}
+
+	/** Sets the active status of the tracker. */
+	set active (value) {
+		const original = this.#current
+
+		// Activate the tracker.
+		if (value === true) {
+			const upcoming = this.getEntryAt('next-turn')
+			if (original !== null || upcoming === null) return
+			this.#safelyCycleTurn(null, upcoming)
+		}
+
+		// Deactivate the tracker.
+		else if (value === false) {
+			if (original === null) return
+			this.#safelyCycleTurn(original, null, {skip: true})
+		}
+	}
+
+	/** Points to the current turn in the turn list. */
+	get currentIndex ( ) {
+		if (this.#current == null) return null
+		else return this.#current.index
+	}
+
+	/** Obtains the current turn, if there is one. */
+	get currentTurn ( ) {
+		if (this.#current == null) return null
+		else return this.#current.turn
+	}
+
+	/** Represents how many turns have passed. */
+	get turnCounter ( ) {return this.#turnCounter}
+
+	/** Represents how many rounds have passed. */
+	get roundCounter ( ) {return this.#roundCounter}
+
+	/** The numeric representation of the current turn. */
+	get turnOrdinal ( ) {return this.turnCounter + 1}
+
+	/** The numeric representation of the current round. */
+	get roundOrdinal ( ) {return this.roundCounter + 1}
+
+	/**
+	Provides the index of the next turn,
+		if a valid turn exists in the tracker.
+
+	---
+
+	@returns
+	This method returns an index pointing to a turn in the
+		tracker, with a single exception…
+	If the tracker is empty or has no valid turns, then a
+		`null` value gets returned, instead.
+	This represents the intentional absence of a turn.
+	**/
+	getEntryAt (
+		index: integer | TurnRelation | null
+	): MetaTurn<Turn> {
+		// An empty tracker contains no turns.
+		if (index == null || this.turns.length === 0) return null
+
+		let sliceIndex = 0 // Named for more clarity.
+
+		// Check for a relative index input,
+		//	or sanitize a numeric index input.
+		if (typeof index === 'number') {
+			sliceIndex = Math.max(index, 0)
+		}
+		else if (index === 'next-turn') {
+			if (this.#current == null) sliceIndex = 0
+			else sliceIndex = this.#current.index + 1
+		}
+
+		// Slice current turns into two parts,
+		//	then get the next turn and first turn.
+		const nextTurns = this.turns.slice(sliceIndex)
+		const prevTurns = this.turns.slice(0, sliceIndex)
+
+		const nextIndex = nextTurns.findIndex(this.#filterMethod)
+		const firstIndex = prevTurns.findIndex(this.#filterMethod)
+		let foundIndex
+
+		if (nextIndex !== -1) foundIndex = sliceIndex + nextIndex
+		else if (firstIndex !== -1) foundIndex = firstIndex
+		else return null
+
+		const foundTurn = this.turns.at(foundIndex)
+		if (foundTurn === undefined) throw invalidTurnError
+		return {index: foundIndex, turn: foundTurn} as const
+	}
+
+	/* ************************ */
+	/* # LIST MUTATOR METHODS # */
+	/* ************************ */
+
+	/**
+	Adds one or more turns to the list, while maintaining
+		sort-order and tracking the current turn index.
+	**/
+	add (...turns: Array<Turn>) {
+		// Remove duplicates from the input.
+		// Each of the tracker's turns should be unique.
+		turns = turns.filter((turn, index) => (
+			// The internal list cannot include the turn already.
+			!this.turns.includes(turn) &&
+			// The input cannot include any turn more than once.
+			!turns.slice(index + 1).includes(turn)
+		))
+
+		// Safely add the specified turns, one-at-a-time.
+		turns.forEach((turn) => {
+			const callback = ( ) => this.#listRef.add(turn)
+			this.#safelyRunWithSideEffects(callback)
+		})
+
+		return [...turns] as const
+	}
+
+	/**
+	Removes one or more turns from the list,
+		while tracking the current index.
+	If the current tracked turn is removed,
+		it gets skipped for the next turn.
+	**/
+	remove (...turns: Array<Turn>) {
+		const removals: Array<Turn> = [ ]
+
+		// Safely remove the specified turns, one-at-a-time.
+		turns.forEach((turn) => {
+			const callback = ( ) => {
+				const removed = this.#listRef.remove(turn)
+				if (removed.length > 0) removals.push(turn)
+			}
+			this.#safelyRunWithSideEffects(callback)
+		})
+
+		return [...removals] as const
+	}
+
+	/**
+	Sorts the turn list, while maintaining sort-order
+		and tracking the current turn index.
+	This is available to class instances, in case a turn's
+		properties change (affecting sort-order).
+	**/
+	sort ( ) {
+		const callback = ( ) => this.#listRef.sort( )
+		return this.#safelyRunWithSideEffects(callback)
+	}
+
+	/* ************************ */
+	/* # INDEX CYCLER METHODS # */
+	/* ************************ */
+
+	/** Increments turn & round cyclers as necessary. */
+	next ( ) {
+		const current = this.#current
+		const upcoming = this.getEntryAt('next-turn')
+		this.#safelyCycleTurn(current, upcoming)
+	}
+
+	/* ***************************** */
+	/* # METADATA ACCESSOR METHODS # */
+	/* ***************************** */
+
+	/** Creates a human readable string with the tracker. */
+	toString ( ) {
+		return (
+			'------------------------------------\n\n' +
+			`current index:\t${this.currentIndex}\n` +
+			`current turn:\t${this.currentTurn}\n` +
+			`turn number:\t${this.turnOrdinal}\n` +
+			`round number:\t${this.roundOrdinal}\n` +
+			makeTable(this.turns)
+		)
+	}
+
+	/** Generates a representation of the tracker's data. */
+	toData ( ) {
+		return {
+			turns: this.turns,
+			currentIndex: this.currentIndex,
+			turnCounter: this.turnCounter,
+			roundCounter: this.roundCounter,
+		} as const
+	}
+
+	/** Emits a JSON-ified representation of the tracker. */
+	toJSON ( ) {return JSON.stringify(this.toData( ))}
+
+	/** Emits a JSON5-ified representation of the tracker. */
+	toJSON5 ( ) {return JSON5.stringify(this.toData( ))}
+}
+
+export {TurnTracker}
+export type {TurnTrackerArgs}

--- a/source/classes/TurnTracker/TurnTrackerEvents.mts
+++ b/source/classes/TurnTracker/TurnTrackerEvents.mts
@@ -1,0 +1,173 @@
+import type {TurnTracker} from '#classes/TurnTracker'
+
+type ValArray <Val> = Val | Array<Val>
+
+type StateEventName = (
+	| 'activate-tracker'
+	| 'deactivate-tracker'
+	| 'start-round'
+	| 'end-round'
+)
+
+type TurnEventName = (
+	| 'add-turn'
+	| 'remove-turn'
+	| 'start-turn'
+	| 'skip-turn'
+	| 'end-turn'
+)
+
+/**
+A currated set of the event names that are available
+	for turn trackers. They are all strings.
+**/
+type EventName = (
+	| StateEventName
+	| TurnEventName
+)
+
+type StateEventCallback = (
+	( ) => void
+)
+
+type TurnEventCallback <Turn> = (
+	(turn: Turn) => void
+)
+
+type EventCallback <Turn> = (
+	| StateEventCallback
+	| TurnEventCallback<Turn>
+)
+
+type StateEventListener <Turn> = (
+	(tracker: TurnTracker<Turn>) => void
+)
+
+type TurnEventListener <Turn> = (
+	(tracker: TurnTracker<Turn>, turn: Turn) => void
+)
+
+type EventListener <Turn> = (
+	| StateEventListener<Turn>
+	| TurnEventListener<Turn>
+)
+
+type EventListeners <Turn> = (
+	| Partial<Record<StateEventName, ValArray<StateEventListener<Turn>>>>
+	| Partial<Record<TurnEventName, ValArray<TurnEventListener<Turn>>>>
+)
+
+/** A helper class for managing turn tracker events. */
+class TurnTrackerEvents <Turn = unknown> {
+	// Private property to store listeners of each event type.
+	#listeners: Partial<Record<EventName, Array<Function>>>
+	// Adding the tracker avoids the need to have it
+	//	as a parameter in dispatched callbacks.
+	#tracker: TurnTracker<Turn>
+
+	/** Requires a reference to the turn tracker. */
+	constructor (
+		tracker: TurnTracker<Turn>,
+		listeners?: EventListeners<Turn>,
+	) {
+		this.#listeners = { }
+		this.#tracker = tracker
+
+		if (listeners == null) return
+
+		// We expect errors here as using `entries` jumbles up
+		//	the typing system for `EventListenersInput`...
+		Object.entries(listeners).forEach(([name, data]) => {
+			if (typeof data === 'function') {
+				const listener = data
+				/* @ts-expect-error */
+				this.addEventListener(name, listener)
+			}
+			else data.forEach((listener) => {
+				/* @ts-expect-error */
+				this.addEventListener(name, listener)
+			})
+		})
+	}
+
+	/** Adds an event listener to the call stack. */
+	// Method Overload for addingtracker state events.
+	addEventListener (
+		name: StateEventName,
+		listener: StateEventListener<Turn>,
+	): void
+
+	// Method Overload for adding tracker turn events.
+	addEventListener (
+		name: TurnEventName,
+		listener: TurnEventListener<Turn>,
+	): void
+
+	// Primary method signature for adding event listeners.
+	addEventListener (
+		name: EventName,
+		listener: EventListener<Turn>,
+	): void {
+		const listeners = (this.#listeners[name] ??= [ ])
+		listeners.push(listener)
+	}
+
+	/** Removes an event listener from the call stack. */
+	// Method Overload for removing tracker state events.
+	removeEventListener (
+		name: StateEventName,
+		listener: StateEventListener<Turn>,
+	): void
+
+	// Method Overload for removing tracker turn events.
+	removeEventListener (
+		name: TurnEventName,
+		listener: TurnEventListener<Turn>,
+	): void
+
+	// Primary method signature for removing event listeners.
+	removeEventListener (
+		name: EventName,
+		listener: EventListener<Turn>,
+	): void {
+		const listeners = this.#listeners[name] ?? [ ]
+		const index = listeners.indexOf(listener)
+		if (index !== -1) listeners.splice(index, 1)
+		if (listeners.length === 0) delete this.#listeners[name]
+	}
+
+	/** Returns a function to execute a stack of callbacks. */
+	// Method Overload for dispatching state events.
+	#dispatchEvent (name: StateEventName): StateEventCallback
+
+	// Method Overload for dispatching turn events.
+	#dispatchEvent (name: TurnEventName): TurnEventCallback<Turn>
+
+	// Primary method signature for dispatching events.
+	#dispatchEvent (name: EventName): EventCallback<Turn> {
+		// Returns a function to execute a stack of callbacks.
+		return (...parameters: Array<unknown>) => {
+			const listeners = this.#listeners[name] ?? [ ]
+			listeners.forEach((callback) => {
+				// Notice how `#tracker` is added as an argument.
+				callback(this.#tracker, ...parameters)
+			})
+		}
+	}
+
+	// Tracker State Events //
+	onActivateTracker( ) {this.#dispatchEvent('activate-tracker')( )}
+	onDeactivateTracker( ) {this.#dispatchEvent('deactivate-tracker')( )}
+	onStartRound( ) {this.#dispatchEvent('start-round')( )}
+	onEndRound( ) {this.#dispatchEvent('end-round')( )}
+
+	// Turn State Events //
+	onAddTurn(turn: Turn) {this.#dispatchEvent('add-turn')(turn)}
+	onRemoveTurn(turn: Turn) {this.#dispatchEvent('remove-turn')(turn)}
+	onStartTurn(turn: Turn) {this.#dispatchEvent('start-turn')(turn)}
+	onSkipTurn(turn: Turn) {this.#dispatchEvent('skip-turn')(turn)}
+	onEndTurn(turn: Turn) {this.#dispatchEvent('end-turn')(turn)}
+}
+
+export {TurnTrackerEvents}
+export type {EventName, EventListeners}

--- a/source/classes/TurnTracker/index.mts
+++ b/source/classes/TurnTracker/index.mts
@@ -1,2 +1,5 @@
 export {TurnTracker} from './TurnTracker.mts'
+export {TurnTrackerEvents} from './TurnTrackerEvents.mts'
+
 export type {TurnTrackerArgs} from './TurnTracker.mts'
+export type {EventName, EventListeners} from './TurnTrackerEvents.mts'

--- a/source/classes/TurnTracker/index.mts
+++ b/source/classes/TurnTracker/index.mts
@@ -1,0 +1,2 @@
+export {TurnTracker} from './TurnTracker.mts'
+export type {TurnTrackerArgs} from './TurnTracker.mts'

--- a/source/types/aliases.d.mts
+++ b/source/types/aliases.d.mts
@@ -4,9 +4,15 @@ type checkMethod<T> = (item: T) => boolean
 type matchMethod<T> = (itemA: T, itemB: T) => boolean
 type sortMethod<T> = (itemA: T, itemB: T) => number
 
+type Constructor <
+	Instance = unknown,
+	Arguments extends Array<unknown> = [ ],
+> = new (...args: Arguments) => Instance
+
 export type {
 	integer,
 	checkMethod,
 	matchMethod,
 	sortMethod,
+	Constructor,
 }

--- a/source/types/aliases.d.mts
+++ b/source/types/aliases.d.mts
@@ -1,0 +1,12 @@
+type integer = number
+
+type checkMethod<T> = (item: T) => boolean
+type matchMethod<T> = (itemA: T, itemB: T) => boolean
+type sortMethod<T> = (itemA: T, itemB: T) => number
+
+export type {
+	integer,
+	checkMethod,
+	matchMethod,
+	sortMethod,
+}


### PR DESCRIPTION
There are two large sections to this code, including a "Turn Tracker" class and a "Tree" class.

The Turn Tracker will cycle through participants in a round-robin way. Perfect for turns in a role-playing game. Like in D&D, you have a turn order to walk through. However it can be used in other ways, like for taking turns doing chores in some API, or something. Could be abstracted out into its own open-source package on npm, later.

The Tree class will be useful for prototyping inventory items, and tracking inventories in general. To be honest, I coded this a while ago, so I don't remember why I needed a tree class but it is *very* comprehensive and can be expanded to other uses as well. Could also be its own open-source package on npm!